### PR TITLE
fixing ReferenceError: strEnt is not defined

### DIFF
--- a/lib/sax-parser.js
+++ b/lib/sax-parser.js
@@ -676,6 +676,8 @@
     iB = iB || 0;
     iE = iE || strD.length;
 
+    var strEnt;
+
     switch (strD.substring(iB, iE)) {
       case "amp":
         strEnt = "&";


### PR DESCRIPTION
I’m using a package that is depending on this package and I came across one small syntax issue leading to a `ReferenceError: strEnt is not defined` in recent versions of node and Cloudflare Worker’s environment.

This small change will fix that.

Cheers